### PR TITLE
fix: static-audit mechanical defects (settings/PID/concurrency/web-input hardening)

### DIFF
--- a/src/common/datatypes/mutex.cpp
+++ b/src/common/datatypes/mutex.cpp
@@ -1,0 +1,8 @@
+#include "freertos/FreeRTOS.h" // must precede semphr.h (pulled in by mutex.h)
+#include "mutex.h"
+
+// Single definition of the shared mutex handles declared `extern` in mutex.h.
+// Created (xSemaphoreCreateMutex) in main.cpp setup(); referenced by every TU that includes mutex.h.
+SemaphoreHandle_t i2c1_mutex;
+SemaphoreHandle_t spi1_mutex;
+SemaphoreHandle_t sys1_mutex;

--- a/src/common/datatypes/mutex.h
+++ b/src/common/datatypes/mutex.h
@@ -3,8 +3,11 @@
 
 #include "freertos/semphr.h"
 
-static SemaphoreHandle_t i2c1_mutex;
-static SemaphoreHandle_t spi1_mutex;
-static SemaphoreHandle_t sys1_mutex;
+// extern (not static): one shared instance across all translation units. `static` here gave each
+// including .cpp its own NULL copy — only main.cpp's set got initialized, so other TUs (e.g.
+// serial_com.cpp) saw NULL handles and their locking was non-functional. Definitions live in mutex.cpp.
+extern SemaphoreHandle_t i2c1_mutex;
+extern SemaphoreHandle_t spi1_mutex;
+extern SemaphoreHandle_t sys1_mutex;
 
 #endif

--- a/src/core/controllers/AerPID.cpp
+++ b/src/core/controllers/AerPID.cpp
@@ -279,6 +279,7 @@ bool AerPID::compute()
         // scale output using temperature delta for better stability at set point
         // double _output = deltaScaleOutput(delta, output);
         double _output = max(0.0, output);
+        if (isnan(_output)) _output = 0.0; // AER-19 hardening: never cast/act on a NaN output (xOutput cast would be UB; force safe-off, not dead-code happenstance)
 
         // convert output double to uint32 for ledcWrite
         xOutput = static_cast<uint32_t>(_output);

--- a/src/core/controllers/AerPID.cpp
+++ b/src/core/controllers/AerPID.cpp
@@ -175,6 +175,17 @@ void AerPID::tick()
             // (was `_pidTickMax * (5 / 1000)` = integer 0 — a no-op; made explicit.)
             _tick = 0;
         }
+        // Floor the counter so it can never march into int16 underflow. When compute()
+        // returns false (PID disabled, over-temp latch, or sample-time not yet elapsed)
+        // the original code left _tick decrementing unbounded: after ~6 min it reached
+        // INT16_MIN and wrapped to +32767, making `_tick-- <= 0` false and freezing
+        // compute() for ~6 min. Cadence is owned by compute()'s own sampleTime gate, so
+        // re-flooring to 0 is behavior-preserving (compute() is still evaluated every
+        // tick while _tick <= 0).
+        if (_tick < 0)
+        {
+            _tick = 0;
+        }
     }
 
     // timer trigger var

--- a/src/core/controllers/AerPID.cpp
+++ b/src/core/controllers/AerPID.cpp
@@ -170,9 +170,10 @@ void AerPID::tick()
         //  Process PID computation
         if (compute())
         {
-            // reset pid tick
-            //_tick = _pidTickMax;
-            _tick = _pidTickMax * (5 / 1000);
+            // reset pid tick. cadence is owned by the elapsed-time gate in compute()
+            // (sampleTime via getPidTick()); this just keeps the _tick-- guard satisfied.
+            // (was `_pidTickMax * (5 / 1000)` = integer 0 — a no-op; made explicit.)
+            _tick = 0;
         }
     }
 
@@ -986,7 +987,10 @@ AerPID::MeasureResult AerPID::measureElementTemperatureAsync()
 
         if (millis() - _measLastTime > FAULT_TIMEOUT || _faultsRecent >= 3)
         {
-            _faultsRecent--;
+            if (_faultsRecent > 0)
+            {
+                _faultsRecent--; // guard: _faultsRecent is unsigned; timeout branch can reach here at 0
+            }
             addToMES_TEMP(celsius);
             _measLastTime = millis();
             Serial.println(F("(async) Measure Fault Recovery! Forcing measure..."));

--- a/src/storage/pidStor.cpp
+++ b/src/storage/pidStor.cpp
@@ -58,6 +58,7 @@ void PidStor::load_pid(double &kP, double &kI, double &kD)
     const char *filename = "pid.dat";
     int leng = 30;
     char storageData[leng];
+    memset(storageData, 0, leng); // deterministic 0.0 decode if file missing/short (guards then apply defaults)
 
     flash->openFile(filename, storageData, leng);
 
@@ -145,6 +146,7 @@ void PidStor::load_pid_2(double &kP, double &kI, double &kD)
     const char *filename = "pid2.dat";
     int leng = 30;
     char storageData[leng];
+    memset(storageData, 0, leng); // deterministic 0.0 decode if file missing/short (guards then apply defaults)
 
     flash->openFile(filename, storageData, leng);
 

--- a/src/storage/tempStor.cpp
+++ b/src/storage/tempStor.cpp
@@ -103,7 +103,7 @@ void TempStor::save1()
     }
     else if (i < 16)
     {
-      data[i] = mt.array[i + 8];
+      data[i] = mt.array[i - 8];
     }
   }
 
@@ -132,7 +132,7 @@ void TempStor::save2()
     }
     else if (i < 16)
     {
-      data[i] = mt.array[i + 8];
+      data[i] = mt.array[i - 8];
     }
   }
 

--- a/src/tasks/encTask.h
+++ b/src/tasks/encTask.h
@@ -2626,6 +2626,10 @@ void onEb1Encoder(EncoderButton &eb)
         {
             enc_am->getAerPID(elementIndex)->kP += 0.1 * dir;
         }
+        if (enc_am->getAerPID(elementIndex)->kP < 0)
+        {
+            enc_am->getAerPID(elementIndex)->kP = 0;
+        }
         enc_aerGUI->updateMenu();
         enc_am->setPressTick(300);
         enc_am->getAerPID(elementIndex)->pid_saved = false;
@@ -2642,6 +2646,10 @@ void onEb1Encoder(EncoderButton &eb)
         {
             enc_am->getAerPID(elementIndex)->kI += 0.001 * dir;
         }
+        if (enc_am->getAerPID(elementIndex)->kI < 0)
+        {
+            enc_am->getAerPID(elementIndex)->kI = 0;
+        }
         enc_aerGUI->updateMenu();
         enc_am->setPressTick(300);
         enc_am->getAerPID(elementIndex)->pid_saved = false;
@@ -2657,6 +2665,10 @@ void onEb1Encoder(EncoderButton &eb)
         else if (eb.increment() < 0)
         {
             enc_am->getAerPID(elementIndex)->kD += 0.5 * dir;
+        }
+        if (enc_am->getAerPID(elementIndex)->kD < 0)
+        {
+            enc_am->getAerPID(elementIndex)->kD = 0;
         }
         enc_aerGUI->updateMenu();
         enc_am->setPressTick(300);
@@ -2689,6 +2701,14 @@ void onEb1Encoder(EncoderButton &eb)
             {
                 enc_am->getAerPID(elementIndex)->SET_TEMP += amt * dir;
             }
+        }
+        if (enc_am->getAerPID(elementIndex)->SET_TEMP < 0)
+        {
+            enc_am->getAerPID(elementIndex)->SET_TEMP = 0;
+        }
+        if (enc_am->getAerPID(elementIndex)->SET_TEMP > enc_am->getAerPID(elementIndex)->SET_TEMP_MAX)
+        {
+            enc_am->getAerPID(elementIndex)->SET_TEMP = enc_am->getAerPID(elementIndex)->SET_TEMP_MAX;
         }
         enc_am->setPressTick(400);
         enc_am->updateTempStor(elementIndex, true);

--- a/src/tasks/saveTask.h
+++ b/src/tasks/saveTask.h
@@ -51,7 +51,7 @@ void save_task(void *pvParameters)
 
         // Load the PID values from Flash
         pidStor.load_pid(am->getAerPID(0)->kP, am->getAerPID(0)->kI, am->getAerPID(0)->kD);
-        if (am->getAerPID(0)->kP <= 0.01)
+        if (isnan(am->getAerPID(0)->kP) || am->getAerPID(0)->kP <= 0.01)
         {
             am->getAerPID(0)->kP = 2.0;
         }
@@ -59,7 +59,7 @@ void save_task(void *pvParameters)
         {
             am->getAerPID(0)->kI = 0.025;
         }
-        if (am->getAerPID(0)->kD <= 0)
+        if (isnan(am->getAerPID(0)->kD) || am->getAerPID(0)->kD <= 0)
         {
             am->getAerPID(0)->kD = 7.0;
         }
@@ -73,7 +73,7 @@ void save_task(void *pvParameters)
 
 #if AERPID_COUNT == 2
         pidStor.load_pid_2(am->getAerPID(1)->kP, am->getAerPID(1)->kI, am->getAerPID(1)->kD);
-        if (am->getAerPID(1)->kP <= 0.1)
+        if (isnan(am->getAerPID(1)->kP) || am->getAerPID(1)->kP <= 0.1)
         {
             am->getAerPID(1)->kP = 2.0;
         }
@@ -81,7 +81,7 @@ void save_task(void *pvParameters)
         {
             am->getAerPID(1)->kI = 0.025;
         }
-        if (am->getAerPID(1)->kD <= 0)
+        if (isnan(am->getAerPID(1)->kD) || am->getAerPID(1)->kD <= 0)
         {
             am->getAerPID(1)->kD = 7.0;
         }

--- a/src/tasks/saveTask.h
+++ b/src/tasks/saveTask.h
@@ -59,7 +59,7 @@ void save_task(void *pvParameters)
         {
             am->getAerPID(0)->kI = 0.025;
         }
-        if (am->getAerPID(0)->kD < 0)
+        if (am->getAerPID(0)->kD <= 0)
         {
             am->getAerPID(0)->kD = 7.0;
         }
@@ -81,7 +81,7 @@ void save_task(void *pvParameters)
         {
             am->getAerPID(1)->kI = 0.025;
         }
-        if (am->getAerPID(1)->kD < 0)
+        if (am->getAerPID(1)->kD <= 0)
         {
             am->getAerPID(1)->kD = 7.0;
         }

--- a/src/tasks/saveTask.h
+++ b/src/tasks/saveTask.h
@@ -55,14 +55,10 @@ void save_task(void *pvParameters)
         {
             am->getAerPID(0)->kP = 2.0;
         }
-        /*if (am->getAerPID(0)->kI <= 0.0001)
+        if (isnan(am->getAerPID(0)->kI) || am->getAerPID(0)->kI <= 0.0001 || am->getAerPID(0)->kI >= 5.0001)
         {
             am->getAerPID(0)->kI = 0.025;
         }
-        else if (am->getAerPID(0)->kI >= 5.0001)
-        {
-            am->getAerPID(0)->kI = 0.025;
-        }*/
         if (am->getAerPID(0)->kD < 0)
         {
             am->getAerPID(0)->kD = 7.0;
@@ -81,10 +77,10 @@ void save_task(void *pvParameters)
         {
             am->getAerPID(1)->kP = 2.0;
         }
-        /*if (am->getAerPID(1)->kI <= 0.0001)
+        if (isnan(am->getAerPID(1)->kI) || am->getAerPID(1)->kI <= 0.0001 || am->getAerPID(1)->kI >= 5.0001)
         {
             am->getAerPID(1)->kI = 0.025;
-        }*/
+        }
         if (am->getAerPID(1)->kD < 0)
         {
             am->getAerPID(1)->kD = 7.0;

--- a/src/web/webServer.cpp
+++ b/src/web/webServer.cpp
@@ -1680,11 +1680,18 @@ void WebServer::processSocketData(char *data, AsyncWebSocketClient *client)
                 {
                     bd.bytes[i] = data[3 + i];
                 }
-                val = xAerPID1.kP = bd.value;
+                if (isnan(bd.value) || bd.value < 0) // AER-19: reject NaN/negative gain from raw network bytes
+                {
+                    val = xAerPID1.kP; // keep current; no write, no flash-dirty
+                }
+                else
+                {
+                    val = xAerPID1.kP = bd.value;
+                    xAerPID1.setTunings(false);
+                    aerManager.setPressTick(600);
+                    xAerPID1.pid_saved = false;
+                }
                 Serial.println(">>> P Val >> " + String(val));
-                xAerPID1.setTunings(false);
-                aerManager.setPressTick(600);
-                xAerPID1.pid_saved = false;
             }
 
             SocketCmdOp *reply = new SocketCmdOp(SerialCommand::CMD_PID);
@@ -1710,11 +1717,18 @@ void WebServer::processSocketData(char *data, AsyncWebSocketClient *client)
                 {
                     bd.bytes[i] = data[3 + i];
                 }
-                val = xAerPID1.kI = bd.value;
+                if (isnan(bd.value) || bd.value < 0) // AER-19: reject NaN/negative gain from raw network bytes
+                {
+                    val = xAerPID1.kI; // keep current; no write, no flash-dirty
+                }
+                else
+                {
+                    val = xAerPID1.kI = bd.value;
+                    xAerPID1.setTunings(false);
+                    aerManager.setPressTick(600);
+                    xAerPID1.pid_saved = false;
+                }
                 Serial.println(">>> I Val >> " + String(val, 4));
-                xAerPID1.setTunings(false);
-                aerManager.setPressTick(600);
-                xAerPID1.pid_saved = false;
             }
             SocketCmdOp *reply = new SocketCmdOp(SerialCommand::CMD_PID);
             reply->AddClient(client->id());
@@ -1739,11 +1753,18 @@ void WebServer::processSocketData(char *data, AsyncWebSocketClient *client)
                 {
                     bd.bytes[i] = data[3 + i];
                 }
-                val = xAerPID1.kD = bd.value;
+                if (isnan(bd.value) || bd.value < 0) // AER-19: reject NaN/negative gain from raw network bytes
+                {
+                    val = xAerPID1.kD; // keep current; no write, no flash-dirty
+                }
+                else
+                {
+                    val = xAerPID1.kD = bd.value;
+                    xAerPID1.setTunings(false);
+                    aerManager.setPressTick(600);
+                    xAerPID1.pid_saved = false;
+                }
                 Serial.println(">>> D Val >> " + String(val));
-                xAerPID1.setTunings(false);
-                aerManager.setPressTick(600);
-                xAerPID1.pid_saved = false;
             }
             SocketCmdOp *reply = new SocketCmdOp(SerialCommand::CMD_PID);
             reply->AddClient(client->id());
@@ -2179,11 +2200,18 @@ void WebServer::processSocketData(char *data, AsyncWebSocketClient *client)
                 {
                     bd.bytes[i] = data[3 + i];
                 }
-                val = xAerPID2.kP = bd.value;
+                if (isnan(bd.value) || bd.value < 0) // AER-19: reject NaN/negative gain from raw network bytes
+                {
+                    val = xAerPID2.kP; // keep current; no write, no flash-dirty
+                }
+                else
+                {
+                    val = xAerPID2.kP = bd.value;
+                    xAerPID2.setTunings(true);
+                    aerManager.setPressTick(600);
+                    xAerPID2.pid_saved = false;
+                }
                 Serial.println(">>> P Val >> " + String(val));
-                xAerPID2.setTunings(true);
-                aerManager.setPressTick(600);
-                xAerPID2.pid_saved = false;
             }
 
             SocketCmdOp *reply = new SocketCmdOp(SerialCommand::CMD_PID2);
@@ -2209,11 +2237,18 @@ void WebServer::processSocketData(char *data, AsyncWebSocketClient *client)
                 {
                     bd.bytes[i] = data[3 + i];
                 }
-                val = xAerPID2.kI = bd.value;
+                if (isnan(bd.value) || bd.value < 0) // AER-19: reject NaN/negative gain from raw network bytes
+                {
+                    val = xAerPID2.kI; // keep current; no write, no flash-dirty
+                }
+                else
+                {
+                    val = xAerPID2.kI = bd.value;
+                    xAerPID2.setTunings(true);
+                    aerManager.setPressTick(600);
+                    xAerPID2.pid_saved = false;
+                }
                 Serial.println(">>> I Val >> " + String(val, 4));
-                xAerPID2.setTunings(true);
-                aerManager.setPressTick(600);
-                xAerPID2.pid_saved = false;
             }
             SocketCmdOp *reply = new SocketCmdOp(SerialCommand::CMD_PID2);
             reply->AddClient(client->id());
@@ -2238,11 +2273,18 @@ void WebServer::processSocketData(char *data, AsyncWebSocketClient *client)
                 {
                     bd.bytes[i] = data[3 + i];
                 }
-                val = xAerPID2.kD = bd.value;
+                if (isnan(bd.value) || bd.value < 0) // AER-19: reject NaN/negative gain from raw network bytes
+                {
+                    val = xAerPID2.kD; // keep current; no write, no flash-dirty
+                }
+                else
+                {
+                    val = xAerPID2.kD = bd.value;
+                    xAerPID2.setTunings(true);
+                    aerManager.setPressTick(600);
+                    xAerPID2.pid_saved = false;
+                }
                 Serial.println(">>> D Val >> " + String(val));
-                xAerPID2.setTunings(true);
-                aerManager.setPressTick(600);
-                xAerPID2.pid_saved = false;
             }
             SocketCmdOp *reply = new SocketCmdOp(SerialCommand::CMD_PID2);
             reply->AddClient(client->id());
@@ -2283,9 +2325,12 @@ void WebServer::processSocketData(char *data, AsyncWebSocketClient *client)
                 val = bd.value;
             }
             Serial.printf(">> Set Temp(c): %f \n", val);
-            xAerPID1.SET_TEMP = val;
-            aerManager.updateTempStor(0, true);
-            aerManager.setPressTick(250);
+            if (!isnan(val) && val >= 0 && val <= xAerPID1.SET_TEMP_MAX) // AER-19: reject NaN/out-of-range network target; keeps thermal-cutoff floor
+            {
+                xAerPID1.SET_TEMP = val;
+                aerManager.updateTempStor(0, true);
+                aerManager.setPressTick(250);
+            }
         }
         else
         {
@@ -2328,9 +2373,12 @@ void WebServer::processSocketData(char *data, AsyncWebSocketClient *client)
                 val = bd.value;
             }
             Serial.printf(">> Set Temp(c): %f \n", val);
-            xAerPID2.SET_TEMP = val;
-            aerManager.updateTempStor(1, true);
-            aerManager.setPressTick(250);
+            if (!isnan(val) && val >= 0 && val <= xAerPID2.SET_TEMP_MAX) // AER-19: reject NaN/out-of-range network target; keeps thermal-cutoff floor
+            {
+                xAerPID2.SET_TEMP = val;
+                aerManager.updateTempStor(1, true);
+                aerManager.setPressTick(250);
+            }
         }
         else
         {


### PR DESCRIPTION
Static audit of AerPID3 surfaced 8 mechanical defects across settings-load, PID compute, concurrency, and WebSocket input paths. This branch fixes them off `develop`; no behavioral/feature changes, build-green.

## Fixes
- **AER-06 (compute freeze):** floor `_tick` to prevent int16 underflow freezing `compute()` — the candidate for the reported field-freeze.
- **AER-01:** NaN-guard `kP`/`kD` load fallbacks (caught via diverse-lens review).
- **AER-19:** validate WebSocket-set PID gains + `SET_TEMP` before live write; force SSR output safe-off on NaN instead of relying on dead-code.
- Clamp encoder PID gains (`>=0`) and setpoint (`0..SET_TEMP_MAX`).
- `kD` guard parity with `kP`/`kI` so defaults apply on zeroed load.
- Mutex handles `extern` (were `static` in header → NULL per-TU copies).
- Settings-load + measurement robustness.

Verified across mechanical + by-exclusion review; recovery tag retained. AER-06/AER-15 to be **bench-confirmed** on a dev unit (candidate → confirmed).
